### PR TITLE
chore: update xmldom dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.168",
-    "@types/xmldom": "^0.1.30",
+    "@types/xmldom": "^0.1.31",
     "mocha": "^8.3.2",
     "snyk": "^1.530.0",
     "typedoc": "^0.20.35",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "lodash": "^4.17.21",
     "querystring": "^0.2.1",
-    "xmldom": "^0.5.0",
+    "xmldom": "https://github.com/xmldom/xmldom#v0.7.0",
     "xpath": "^0.0.32"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3900,10 +3900,9 @@ xmlbuilder@~11.0.0:
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
   integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
 
-xmldom@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.5.0.tgz#193cb96b84aa3486127ea6272c4596354cb4962e"
-  integrity sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==
+"xmldom@https://github.com/xmldom/xmldom#v0.7.0":
+  version "0.7.0"
+  resolved "https://github.com/xmldom/xmldom#c568938641cc1f121cef5b4df80fcfda1e489b6e"
 
 xpath@^0.0.32:
   version "0.0.32"

--- a/yarn.lock
+++ b/yarn.lock
@@ -462,10 +462,10 @@
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.0.tgz#215c231dff736d5ba92410e6d602050cce7e273f"
   integrity sha512-eQ9qFW/fhfGJF8WKHGEHZEyVWfZxrT+6CLIJGBcZPfxUh/+BnEj+UCGYMlr9qZuX/2AltsvwrGqp0LhEW8D0zQ==
 
-"@types/xmldom@^0.1.30":
-  version "0.1.30"
-  resolved "https://registry.yarnpkg.com/@types/xmldom/-/xmldom-0.1.30.tgz#d36d9a7d64af4693d3b18d5dc02ce432a95be12e"
-  integrity sha512-edqgAFXMEtVvaBZ3YnhamvmrHjoYpuxETmnb0lbTZmf/dXpAsO9ZKotUO4K2rn2SIZBDFCMOuA7fOe0H6dRZcA==
+"@types/xmldom@^0.1.31":
+  version "0.1.31"
+  resolved "https://registry.yarnpkg.com/@types/xmldom/-/xmldom-0.1.31.tgz#519b647cfc66debf82cdf50e49763c8fdee553d6"
+  integrity sha512-bVy7s0nvaR5D1mT1a8ZkByHWNOGb6Vn4yi5TWhEdmyKlAG+08SA7Md6+jH+tYmMLueAwNeWvHHpeKrr6S4c4BA==
 
 "@ungap/promise-all-settled@1.1.2":
   version "1.1.2"


### PR DESCRIPTION
Because of issues in the xmldom repo, npm version 0.7.0 is not available.
v0.7.0 has a needed vulnerability fix, so module is fetch via direct github link.

https://github.com/xmldom/xmldom/issues/271