### PR TITLE
Add support for Capture inputs without AudioDevices

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "lodash": "^4.17.21",
     "querystring": "^0.2.1",
-    "xmldom": "https://github.com/xmldom/xmldom#v0.7.0",
+    "xmldom": "github:xmldom/xmldom#v0.7.0",
     "xpath": "^0.0.32"
   },
   "devDependencies": {

--- a/src/xml-api/input-mapping/generic-av-input-mapper.ts
+++ b/src/xml-api/input-mapping/generic-av-input-mapper.ts
@@ -1,15 +1,28 @@
 // Types
-import { VideoInput } from '../../types/inputs/video'
+import {VideoInput} from '../../types/inputs/video'
 // Mappers
-import { PlayableInputMapper } from './playable-input-mapper'
-import { GenericAudioInputMapper } from './generic-audio-input-mapper'
+import {PlayableInputMapper} from './playable-input-mapper'
+import {GenericAudioInputMapper} from './generic-audio-input-mapper'
 
 export abstract class GenericPlayableWithAudioInputMapper extends PlayableInputMapper {
 
-	map(input: Element, includeLayers: boolean = true): VideoInput {
-		return {
-			...super.map(input, includeLayers),
-			...(new GenericAudioInputMapper).map(input)
-		}
-	}
+  map(input: Element, includeLayers: boolean = true): VideoInput {
+    if (input.attributes.getNamedItem('audiobusses')) {
+      return {
+        ...super.map(input, includeLayers),
+        ...(new GenericAudioInputMapper).map(input)
+      }
+    } else {
+      return {
+        ...super.map(input, includeLayers),
+        audiobusses: [],
+        muted: false,
+        solo: false,
+        volume: -1,
+        balance: 0,
+        audioMeter: {left: 0, right: 0},
+        gainDb: 0
+      }
+    }
+  }
 }


### PR DESCRIPTION
Capture devices like `<input key="8ea28308-df02-43c9-97a7-352ad3968f77" number="3" type="Capture" title="Blackmagic Design" shortTitle="Blackmagic Design" state="Running" position="0" duration="0" loop="False">Blackmagic Design</input>` will throw an unnecessary exception for the required `audiobusses` attribute. This PR fixes the "video-only inputs" with an empty audio input.