### PR TITLE
Add support for Virtual InputType

### DIFF
--- a/src/types/inputs/index.ts
+++ b/src/types/inputs/index.ts
@@ -83,6 +83,7 @@ export type InputType = 'Audio' // Microphone or other live audio source
 	| 'Video' // Video or audio file
 	| 'VideoDelay' // Video delay
 	| 'VideoList' // List of video or audio files
+	| 'Virtual'
 	| 'VirtualSet'
 	| 'VLC' // VLC stream
 	| string // Allow arbitary string value to allow non-listed input types

--- a/src/xml-api/input-mapping/index.ts
+++ b/src/xml-api/input-mapping/index.ts
@@ -25,6 +25,7 @@ export const InputMappers: { [key: string]: BaseInputMapper } = {
 	ImageSequence: new ImageInputMapper,
 	Mix: new MixInputMapper,
 	NDI: new VideoInputMapper,
+	Virtual: new VideoInputMapper,
 	Photos: new PhotosInputMapper,
 	PowerPoint: new PowerpointInputMapper,
 	Replay: new ReplayInputMapper,


### PR DESCRIPTION
VirtualInputs are used a lot in a situation where different PTZ positions have to be controlled. Not more than a copy of a Capture/Video or NDI input thus `VideoInputMapper` 